### PR TITLE
Fix incorrect RoiManager save and open method calls

### DIFF
--- a/src/MyAffineTransform.java
+++ b/src/MyAffineTransform.java
@@ -238,7 +238,7 @@ public class MyAffineTransform {
         RoiManager roiMan = new RoiManager(false);
         roiMan.addRoi(AffineSrc);
         roiMan.addRoi(AffineDst);
-        roiMan.save(dir.resolve(FILE_ROI).toString());
+        roiMan.runCommand("Save", dir.resolve(FILE_ROI).toString());
         roiMan.close();
         
         // Write Matrix.mat
@@ -272,7 +272,7 @@ public class MyAffineTransform {
         }
         
         RoiManager roiMan = new RoiManager(false);
-        roiMan.open(roiPath.toString());
+        roiMan.runCommand("Open", roiPath.toString());
         
         if (roiMan.getCount() < 2) {
             roiMan.close();

--- a/src/MyPerspectiveTransform.java
+++ b/src/MyPerspectiveTransform.java
@@ -218,7 +218,7 @@ public class MyPerspectiveTransform {
         RoiManager roiMan = new RoiManager(false);
         roiMan.addRoi(PerspectiveSrc);
         roiMan.addRoi(PerspectiveDst);
-        roiMan.save(dir.resolve(FILE_ROI).toString());
+        roiMan.runCommand("Save", dir.resolve(FILE_ROI).toString());
         roiMan.close();
         
         // Write Matrix.mat
@@ -252,7 +252,7 @@ public class MyPerspectiveTransform {
         }
         
         RoiManager roiMan = new RoiManager(false);
-        roiMan.open(roiPath.toString());
+        roiMan.runCommand("Open", roiPath.toString());
         
         if (roiMan.getCount() < 2) {
             roiMan.close();


### PR DESCRIPTION
Fixes compilation and runtime errors caused by incorrect usages of the `save` and `open` methods on the `RoiManager` object. The correct way to save and open ROIs programmatically in ImageJ is to use the `runCommand` method.

---
*PR created automatically by Jules for task [10400891476100978763](https://jules.google.com/task/10400891476100978763) started by @WAKU-TAKE-A*